### PR TITLE
Add README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 Kernel config depependencies:
-- CONFIG_IO_STRICT_DEVMEM=n
+- `CONFIG_IO_STRICT_DEVMEM=n`

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+Kernel config depependencies:
+- CONFIG_IO_STRICT_DEVMEM=n


### PR DESCRIPTION
Add a README.md with a reminder to switch off CONFIG_IO_STRICT_DEVMEM. I had debugcc working on 8939 and then tried it on 8280xp. It didn't work but I remembered that there was a CONFIG option that needed to change.
