### PR TITLE
treewide: Add missing measure_gcc to prevent segfaults

### DIFF
--- a/qcm2290.c
+++ b/qcm2290.c
@@ -17,6 +17,8 @@ static struct gcc_mux gcc = {
 		.phys = 0x1400000,
 		.size = 0x1f0000,
 
+		.measure = measure_gcc,
+
 		.enable_reg = 0x30004,
 		.enable_mask = BIT(0),
 

--- a/sc7180.c
+++ b/sc7180.c
@@ -16,6 +16,8 @@ static struct gcc_mux gcc = {
 		.phys =	0x100000,
 		.size = 0x1f0000,
 
+		.measure = measure_gcc,
+
 		.enable_reg = 0x62004,
 		.enable_mask = BIT(0),
 

--- a/sm6125.c
+++ b/sm6125.c
@@ -17,6 +17,8 @@ static struct gcc_mux gcc = {
 		.phys = 0x1400000,
 		.size = 0x1f0000,
 
+		.measure = measure_gcc,
+
 		.enable_reg = 0x30004,
 		.enable_mask = BIT(0),
 

--- a/sm6375.c
+++ b/sm6375.c
@@ -17,6 +17,8 @@ static struct gcc_mux gcc = {
 		.phys = 0x1400000,
 		.size = 0x1f0000,
 
+		.measure = measure_gcc,
+
 		.enable_reg = 0x30004,
 		.enable_mask = BIT(0),
 

--- a/sm8350.c
+++ b/sm8350.c
@@ -44,6 +44,8 @@ static struct gcc_mux gcc = {
 		.phys =	0x162000,
 		.size = 0x1f0000,
 
+		.measure = measure_gcc,
+
 		.enable_reg = 0x8,
 		.enable_mask = BIT(0),
 


### PR DESCRIPTION
oopsie! thanks @travmurav